### PR TITLE
Update the name in the bsconfig.json

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -3,7 +3,7 @@
   comma. If this screws with your editor highlighting, please tell us by filing
   an issue! */
 {
-  "name" : "ReactRePureExample",
+  "name" : "rehydrate",
   "version": "0.0.0",
   "ppx-flags": ["reason/reactjs_jsx_ppx.native"],
   "bsc-flags": ["-w -40 -bs-sort-imports", "-bin-annot"],


### PR DESCRIPTION
This name being different means that the 'require' appears as:
```
ReactRePureExample/lib/js/src/reactRe
```
instead of
```
rehydrate/lib/js/src/reactRe
```

Causes the webpack build to fail and you can't load anything. :)